### PR TITLE
Fixed navigation text visibility in light mode

### DIFF
--- a/src/app/components/language-switcher/language-switcher.component.html
+++ b/src/app/components/language-switcher/language-switcher.component.html
@@ -1,12 +1,12 @@
 <div class="flex items-center space-x-4">
   <button
-    class="text-gray-700 dark:text-gray-300"
+    class="text-gray-300"
     (click)="useLanguage('en')"
     [ngClass]="{ 'font-bold': translate.currentLang === 'en' }">
     EN
   </button>
   <button
-    class="text-gray-700 dark:text-gray-300"
+    class="text-gray-300"
     (click)="useLanguage('de')"
     [ngClass]="{ 'font-bold': translate.currentLang === 'de' }">
     DE

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -1,4 +1,4 @@
-<nav class="bg-white border-gray-200 dark:bg-gray-800">
+<nav class="bg-gray-800 border-gray-200">
   <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
     <a routerLink="/" class="flex items-center space-x-3 rtl:space-x-reverse">
       <img src="https://flowbite.com/docs/images/logo.svg" class="h-8" alt="Flowbite Logo" />

--- a/src/app/components/theme-switcher/theme-switcher.component.html
+++ b/src/app/components/theme-switcher/theme-switcher.component.html
@@ -1,4 +1,4 @@
-<button class="flex gap-3 text-gray-700 dark:text-gray-300" (click)="toggleTheme()">
+<button class="flex gap-3 text-gray-300" (click)="toggleTheme()">
   @if (globalStore.isDarkTheme()) {
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
       <path fill="currentColor" d="M12 20a8 8 0 1 1 0-16 8 8 0 0 1 0 16z" />


### PR DESCRIPTION
Fixed navigation text visibility in light mode by updating colors. For now, the navigation will appear the same in both light and dark modes since theme functionality is not fully implemented yet.

Before the proposed fix is applied:

https://github.com/user-attachments/assets/726df3ad-fe06-4de4-8e16-05a094c98efb


After the proposed fix is applied:

https://github.com/user-attachments/assets/90f049ab-243b-4105-a206-e91eb88ff320


