### PR TITLE
Render real button element for BUTTON controls and support inline editing for TEXT

### DIFF
--- a/src/app/pages/resize/control-editor/control-editor.component.html
+++ b/src/app/pages/resize/control-editor/control-editor.component.html
@@ -2,6 +2,30 @@
 
 <form [formGroup]="form">
   <button (click)="onClose()" class="remove-button">x</button>
+
+  @if (selectedItem()?.type === ControlTypes.BUTTON) {
+  <div class="mb-2">
+    <label for="name" class="block text-gray-700 text-sm font-bold mb-2">Name:</label>
+    <input type="text" id="name" formControlName="name"
+      class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight" />
+  </div>
+  <div class="mb-2">
+    <label for="paddingX" class="block text-gray-700 text-sm font-bold mb-2">Horizontal Padding (px):</label>
+    <input type="number" id="paddingX" formControlName="paddingX" min="0"
+      class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight" />
+  </div>
+  <div class="mb-2">
+    <label for="paddingY" class="block text-gray-700 text-sm font-bold mb-2">Vertical Padding (px):</label>
+    <input type="number" id="paddingY" formControlName="paddingY" min="0"
+      class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight" />
+  </div>
+  <div class="mb-2">
+    <label for="backgroundColor" class="block text-gray-700 text-sm font-bold mb-2">Background Color:</label>
+    <input type="color" id="backgroundColor" formControlName="backgroundColor"
+      class="shadow appearance-none border rounded w-12 h-9 p-0" />
+  </div>
+  }
+
   @if (selectedItem()?.type === ControlTypes.INPUT) {
   <div class="mb-2">
     <label for="name" class="block text-gray-700 text-sm font-bold mb-2">Name:</label>

--- a/src/app/pages/resize/control-editor/control-editor.component.ts
+++ b/src/app/pages/resize/control-editor/control-editor.component.ts
@@ -37,15 +37,37 @@ export class ControlEditorComponent {
         'name',
         new FormControl(currentItem.name, validatorMap.get(currentItem.type) || [Validators.required]),
       );
+
+      if (currentItem.type === ControlTypesEnum.BUTTON) {
+        const style = currentItem.buttonStyle || {};
+
+        this.form.addControl(
+          'backgroundColor',
+          new FormControl(style?.backgroundColor || '#3b82f6'), // Default Tailwind blue-500
+        );
+        this.form.addControl('paddingX', new FormControl(style.paddingX || '16'));
+        this.form.addControl('paddingY', new FormControl(style.paddingY || '8'));
+      }
     });
   }
 
   public onSubmit() {
-    const { name } = this.form.getRawValue();
+    const { name, backgroundColor, paddingX, paddingY } = this.form.getRawValue();
+    const currentItem = this.selectedItem();
 
     const updatedItem: LayoutItemConfig = {
-      ...this.selectedItem()!,
+      ...currentItem!,
       name: name || '',
+      ...(currentItem?.type === ControlTypesEnum.BUTTON
+        ? {
+            buttonStyle: {
+              ...currentItem?.buttonStyle,
+              backgroundColor,
+              paddingX,
+              paddingY,
+            },
+          }
+        : {}),
     };
 
     this.layoutConfigChange.emit(updatedItem);

--- a/src/app/pages/resize/controls.ts
+++ b/src/app/pages/resize/controls.ts
@@ -12,7 +12,7 @@ export const controls: Omit<LayoutItemConfig, 'id'>[] = [
   },
   {
     name: 'text',
-    type: ControlTypesEnum.TEXTAREA,
+    type: ControlTypesEnum.TEXT,
     style: {
       width: '100%',
       backgroundColor: 'gainsboro',

--- a/src/app/pages/resize/resize.component.html
+++ b/src/app/pages/resize/resize.component.html
@@ -4,9 +4,9 @@
   <div class="drop-area flex flex-wrap" cdkDropList id="dropArea" [cdkDropListData]="layoutConfig()"
     [cdkDropListConnectedTo]="[]" cdkDropListOrientation="mixed" (cdkDropListDropped)="drop($event)">
     @for (item of layoutConfig(); track item.id) {
-    <div cdkDrag class="relative mb-2 p-4" [ngStyle]="{
+    <div cdkDrag class="relative mb-2 p-4 flex items-center flex-wrap" [ngStyle]="{
           width: item.style.width,
-          backgroundColor: item.type === ControlTypes.EMPTY ? '#f0f0f0': item.style.backgroundColor,
+          backgroundColor: item.type === ControlTypes.EMPTY ? '#f0f0f0' : item.style.backgroundColor,
         }" [ngClass]="{'active': item.id === selectedItem()?.id}" mwlResizable (click)="onEditControl(item)"
       [enableGhostResize]="true">
       <button class="bg-blue-500 text-white font-bold px-2 mx-1 rounded" (click)="increaseWidth($event, item.id, 2)">
@@ -16,7 +16,29 @@
         -
       </button>
       <div class="placeholder" [ngStyle]="{ width: item.style.width }" *cdkDragPlaceholder></div>
-      {{ item.name }}
+      <ng-container [ngSwitch]="item.type">
+        <button *ngSwitchCase="ControlTypes.BUTTON" class="mx-1 text-white rounded" [ngStyle]="{
+              backgroundColor: item.buttonStyle?.backgroundColor || '#3b82f6',
+              paddingBottom: (item.buttonStyle?.paddingY || 8) + 'px',
+              paddingLeft: (item.buttonStyle?.paddingX || 16) + 'px',
+              paddingRight: (item.buttonStyle?.paddingX || 16) + 'px',
+              paddingTop: (item.buttonStyle?.paddingY || 8) + 'px',
+              width: 'calc(100% - 75px)',
+            }">
+          {{ item.name }}
+        </button>
+        <ng-container *ngSwitchCase="ControlTypes.TEXT">
+          <span (click)="toggleEditing(item.id, true)" *ngIf="!item.isEditing">
+            {{ item.name }}
+          </span>
+          <input *ngIf="item.isEditing && item.type === ControlTypes.TEXT" #inputRef type="text"
+            class="mx-1 focus:outline-none focus:shadow-outline" [ngStyle]="{
+              width: 'calc(100% - 75px)',
+            }" [value]="item.name" (blur)="updateText(inputRef.value, item.id)"
+            (keydown.enter)="updateText(inputRef.value, item.id)" />
+        </ng-container>
+        <span *ngSwitchDefault>{{ item.name }}</span>
+      </ng-container>
       <button (click)="remove($event, item.id)" class="remove-button">x</button>
     </div>
     } @empty {
@@ -31,7 +53,6 @@
   </div>
   }
 </div>
-
 
 <app-action-confirmation-dialog [open]="(openDialog$ | async) || false" (confirmed)="confirm()"
   (cancelled)="cancel()" />

--- a/src/app/pages/resize/resize.component.html
+++ b/src/app/pages/resize/resize.component.html
@@ -16,29 +16,36 @@
         -
       </button>
       <div class="placeholder" [ngStyle]="{ width: item.style.width }" *cdkDragPlaceholder></div>
-      <ng-container [ngSwitch]="item.type">
-        <button *ngSwitchCase="ControlTypes.BUTTON" class="mx-1 text-white rounded" [ngStyle]="{
-              backgroundColor: item.buttonStyle?.backgroundColor || '#3b82f6',
-              paddingBottom: (item.buttonStyle?.paddingY || 8) + 'px',
-              paddingLeft: (item.buttonStyle?.paddingX || 16) + 'px',
-              paddingRight: (item.buttonStyle?.paddingX || 16) + 'px',
-              paddingTop: (item.buttonStyle?.paddingY || 8) + 'px',
-              width: 'calc(100% - 75px)',
-            }">
-          {{ item.name }}
-        </button>
-        <ng-container *ngSwitchCase="ControlTypes.TEXT">
-          <span (click)="toggleEditing(item.id, true)" *ngIf="!item.isEditing">
-            {{ item.name }}
-          </span>
-          <input *ngIf="item.isEditing && item.type === ControlTypes.TEXT" #inputRef type="text"
-            class="mx-1 focus:outline-none focus:shadow-outline" [ngStyle]="{
-              width: 'calc(100% - 75px)',
-            }" [value]="item.name" (blur)="updateText(inputRef.value, item.id)"
-            (keydown.enter)="updateText(inputRef.value, item.id)" />
-        </ng-container>
-        <span *ngSwitchDefault>{{ item.name }}</span>
-      </ng-container>
+      @switch (item.type) {
+      @case (ControlTypes.BUTTON) {
+      <button class="mx-1 text-white rounded" [ngStyle]="{
+            backgroundColor: item.buttonStyle?.backgroundColor || '#3b82f6',
+            paddingBottom: (item.buttonStyle?.paddingY || 8) + 'px',
+            paddingLeft: (item.buttonStyle?.paddingX || 16) + 'px',
+            paddingRight: (item.buttonStyle?.paddingX || 16) + 'px',
+            paddingTop: (item.buttonStyle?.paddingY || 8) + 'px',
+            width: 'calc(100% - 75px)',
+          }">
+        {{ item.name }}
+      </button>
+      }
+      @case (ControlTypes.TEXT) {
+      @if (!item.isEditing) {
+      <span (click)="toggleEditing(item.id, true)">
+        {{ item.name }}
+      </span>
+      }
+      @if (item.isEditing && item.type === ControlTypes.TEXT) {
+      <input #inputRef type="text" class="mx-1 focus:outline-none focus:shadow-outline" [ngStyle]="{
+                width: 'calc(100% - 75px)',
+              }" [value]="item.name" (blur)="updateText(inputRef.value, item.id)"
+        (keydown.enter)="updateText(inputRef.value, item.id)" />
+      }
+      }
+      @default {
+      <span>{{ item.name }}</span>
+      }
+      }
       <button (click)="remove($event, item.id)" class="remove-button">x</button>
     </div>
     } @empty {

--- a/src/app/pages/resize/resize.component.ts
+++ b/src/app/pages/resize/resize.component.ts
@@ -143,6 +143,10 @@ export class ResizeComponent implements ComponentCanDeactivate {
         {
           ...copiedItem,
           id: uuid.v4(),
+          name:
+            copiedItem.type === ControlTypesEnum.TEXT
+              ? 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus nisl risus, eleifend vitae congue in, accumsan in nibh.'
+              : copiedItem.name,
         },
         ...currentConfig.slice(event.currentIndex),
       ]);
@@ -158,6 +162,24 @@ export class ResizeComponent implements ComponentCanDeactivate {
     }
 
     this.selectedItem.set(item);
+  }
+
+  toggleEditing(id: string, value: boolean) {
+    const updated = this.layoutConfig().map(item => (item.id === id ? { ...item, isEditing: value } : item));
+    this.layoutConfig.set(updated);
+  }
+
+  updateText(value: string, id: string) {
+    const updated = this.layoutConfig().map(item =>
+      item.id === id ? { ...item, name: value, isEditing: false } : item,
+    );
+
+    this.layoutConfig.set(updated);
+
+    // Close the Edit Control form
+    if (this.selectedItem()?.id === id) {
+      this.selectedItem.set(null);
+    }
   }
 
   onConfigurationChanged(newItem: LayoutItemConfig) {

--- a/src/app/pages/resize/resize.interface.ts
+++ b/src/app/pages/resize/resize.interface.ts
@@ -2,10 +2,16 @@ import { ControlTypesEnum } from './control-editor/controls.enum';
 
 export interface LayoutItemConfig {
   id: string;
+  isEditing?: boolean;
   name: string;
   type: ControlTypesEnum;
   style: {
     width: string;
     backgroundColor?: string;
+  };
+  buttonStyle?: {
+    backgroundColor?: string;
+    paddingX?: string;
+    paddingY?: string;
   };
 }


### PR DESCRIPTION
- Dragging and dropping a control of type `ControlTypesEnum.BUTTON` now renders a real <button> element in the layout.
Users can edit the button's text, padding, and background color via the Edit Control form.
- For controls of type `ControlTypesEnum.TEXT`:
     - Users can now edit the text inline by clicking on it.
     - Alternatively, the content can still be updated through the Edit Control form.

https://github.com/user-attachments/assets/74f7a5f0-825f-4004-b02e-0d2b697b45cf