### PR TITLE
Switch layoutConfig to 2D rows, improve drag-and-drop

### DIFF
--- a/src/app/pages/resize/available-controls/available-controls.component.html
+++ b/src/app/pages/resize/available-controls/available-controls.component.html
@@ -1,4 +1,4 @@
-<div id="sidebar" cdkDropList [cdkDropListData]="controls()" [cdkDropListConnectedTo]="['dropArea']">
+<div id="sidebar" cdkDropList [cdkDropListData]="controls()" [cdkDropListConnectedTo]="connectedTo">
   @for (control of controls(); track control.name) {
     <div
       cdkDrag

--- a/src/app/pages/resize/available-controls/available-controls.component.ts
+++ b/src/app/pages/resize/available-controls/available-controls.component.ts
@@ -1,5 +1,5 @@
 import { CdkDrag, CdkDropList, DragDropModule } from '@angular/cdk/drag-drop';
-import { Component, signal } from '@angular/core';
+import { Component, Input, signal } from '@angular/core';
 import { controls } from '../controls';
 import { CommonModule } from '@angular/common';
 import { ControlTypesEnum } from '../control-editor/controls.enum';
@@ -11,6 +11,7 @@ import { ControlTypesEnum } from '../control-editor/controls.enum';
   styleUrl: './available-controls.component.scss',
 })
 export class AvailableControlsComponent {
+  @Input() connectedTo: string[] = [];
   controls = signal(controls);
   public ControlTypes = ControlTypesEnum;
 }

--- a/src/app/pages/resize/controls/button/button.component.html
+++ b/src/app/pages/resize/controls/button/button.component.html
@@ -6,7 +6,6 @@
     paddingLeft: (control.buttonStyle?.paddingX || 16) + 'px',
     paddingRight: (control.buttonStyle?.paddingX || 16) + 'px',
     paddingTop: (control.buttonStyle?.paddingY || 8) + 'px',
-    width: 'calc(100% - 75px)',
   }">
   {{ control.name }}
 </button>

--- a/src/app/pages/resize/controls/button/button.component.ts
+++ b/src/app/pages/resize/controls/button/button.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { BaseControlComponent } from '../base.component';
 import { LayoutItemConfig } from '../../resize.interface';
 import { CommonModule } from '@angular/common';
@@ -9,7 +9,7 @@ import { CommonModule } from '@angular/common';
   templateUrl: './button.component.html',
   styleUrl: './button.component.scss',
 })
-export class ButtonComponent extends BaseControlComponent<LayoutItemConfig> {
+export class ButtonComponent extends BaseControlComponent<LayoutItemConfig> implements OnInit {
   ngOnInit() {
     console.log(this.control);
   }

--- a/src/app/pages/resize/default-layout.config.ts
+++ b/src/app/pages/resize/default-layout.config.ts
@@ -2,101 +2,107 @@ import * as uuid from 'uuid';
 import { LayoutItemConfig } from './resize.interface';
 import { ControlTypesEnum } from './control-editor/controls.enum';
 
-export const initialLayout: LayoutItemConfig[] = [
-  {
-    id: uuid.v4(),
-    name: 'Text',
-    type: ControlTypesEnum.TEXT,
-    style: {
-      width: '100%',
-      backgroundColor: '#999',
+export const initialLayout: LayoutItemConfig[][] = [
+  [
+    {
+      id: uuid.v4(),
+      name: 'Text',
+      type: ControlTypesEnum.TEXT,
+      style: {
+        width: '100%',
+        backgroundColor: '#999',
+      },
+      validators: {
+        required: true,
+      },
     },
-    validators: {
-      required: true,
+  ],
+  [
+    {
+      id: uuid.v4(),
+      name: 'Label',
+      type: ControlTypesEnum.INPUT,
+      style: {
+        width: '30%',
+        backgroundColor: 'blue',
+      },
+      validators: {
+        required: false,
+      },
     },
-  },
-  {
-    id: uuid.v4(),
-    name: 'Label',
-    type: ControlTypesEnum.INPUT,
-    style: {
-      width: '30%',
-      backgroundColor: 'blue',
+    {
+      id: uuid.v4(),
+      name: 'Label',
+      type: ControlTypesEnum.INPUT,
+      style: {
+        width: '40%',
+        backgroundColor: 'orange',
+      },
+      validators: {
+        required: false,
+      },
     },
-    validators: {
-      required: false,
+    {
+      id: uuid.v4(),
+      name: 'Label',
+      type: ControlTypesEnum.INPUT,
+      style: {
+        width: '30%',
+        backgroundColor: 'gray',
+      },
+      validators: {
+        required: false,
+      },
     },
-  },
-  {
-    id: uuid.v4(),
-    name: 'Label',
-    type: ControlTypesEnum.INPUT,
-    style: {
-      width: '40%',
-      backgroundColor: 'orange',
+  ],
+  [
+    {
+      id: uuid.v4(),
+      name: 'Label',
+      type: ControlTypesEnum.TEXTAREA,
+      style: {
+        width: '40%',
+        backgroundColor: 'gray',
+      },
+      validators: {
+        required: false,
+      },
     },
-    validators: {
-      required: false,
+    {
+      id: uuid.v4(),
+      name: 'Label',
+      type: ControlTypesEnum.TEXTAREA,
+      style: {
+        width: '40%',
+        backgroundColor: 'green',
+      },
+      validators: {
+        required: false,
+      },
     },
-  },
-  {
-    id: uuid.v4(),
-    name: 'Label',
-    type: ControlTypesEnum.INPUT,
-    style: {
-      width: '30%',
-      backgroundColor: 'gray',
+    {
+      id: uuid.v4(),
+      name: 'click',
+      type: ControlTypesEnum.BUTTON,
+      style: {
+        width: '30%',
+        backgroundColor: 'blue',
+      },
+      validators: {
+        required: false,
+      },
     },
-    validators: {
-      required: false,
+    {
+      id: uuid.v4(),
+      name: 'empty area',
+      type: ControlTypesEnum.EMPTY,
+      style: {
+        width: '60%',
+        backgroundColor: 'orange',
+      },
+      validators: {
+        required: false,
+      },
     },
-  },
-  {
-    id: uuid.v4(),
-    name: 'Label',
-    type: ControlTypesEnum.TEXTAREA,
-    style: {
-      width: '40%',
-      backgroundColor: 'gray',
-    },
-    validators: {
-      required: false,
-    },
-  },
-  {
-    id: uuid.v4(),
-    name: 'Label',
-    type: ControlTypesEnum.TEXTAREA,
-    style: {
-      width: '40%',
-      backgroundColor: 'green',
-    },
-    validators: {
-      required: false,
-    },
-  },
-  {
-    id: uuid.v4(),
-    name: 'click',
-    type: ControlTypesEnum.BUTTON,
-    style: {
-      width: '30%',
-      backgroundColor: 'blue',
-    },
-    validators: {
-      required: false,
-    },
-  },
-  {
-    id: uuid.v4(),
-    name: 'empty area',
-    type: ControlTypesEnum.EMPTY,
-    style: {
-      width: '60%',
-      backgroundColor: 'orange',
-    },
-    validators: {
-      required: false,
-    },
-  },
+  ],
 ];

--- a/src/app/pages/resize/resize.component.html
+++ b/src/app/pages/resize/resize.component.html
@@ -1,5 +1,5 @@
 <div class="flex flex-wrap">
-  <app-available-controls />
+  <app-available-controls [connectedTo]="dropListIds()" />
 
   <div class="flex flex-col flex-1">
     <div class="flex gap-3 align-center justify-center">
@@ -7,67 +7,81 @@
       <button class="py-2 px-4 text-white bg-indigo-600" (click)="openSourceDialog.set(true)">Source</button>
     </div>
 
-    <div
-      class="drop-area flex flex-wrap"
-      cdkDropList
-      id="dropArea"
-      [cdkDropListData]="layoutConfig()"
-      [cdkDropListConnectedTo]="[]"
-      cdkDropListOrientation="mixed"
-      (cdkDropListDropped)="drop($event)">
-      @for (item of layoutConfig(); track item.id) {
-        <div
-          cdkDrag
-          class="relative mb-2 p-4 flex items-center flex-wrap"
-          [ngStyle]="{
-            width: item.style.width,
-            border: '1px dotted #ccc',
-            backgroundColor: '#f9f9f9',
-          }"
-          [ngClass]="{ active: item.id === selectedItem()?.id }"
-          mwlResizable
-          (click)="onEditControl(item)"
-          [enableGhostResize]="true">
-          <div class="placeholder" [ngStyle]="{ width: item.style.width }" *cdkDragPlaceholder></div>
+    @for (row of layoutConfig(); track $index) {
+      <div
+        class="drop-row flex gap-1 mb-2"
+        cdkDropList
+        id="row-{{ $index }}"
+        [cdkDropListData]="row"
+        [cdkDropListConnectedTo]="dropListIds()"
+        cdkDropListOrientation="mixed"
+        (cdkDropListDropped)="drop($event, $index)">
+        @for (item of row; track item.id) {
+          <div
+            cdkDrag
+            [cdkDragData]="item"
+            class="relative p-4 flex items-center flex-wrap"
+            [ngStyle]="{
+              width: item.style.width,
+              border: '1px dotted #ccc',
+              backgroundColor: '#f9f9f9',
+            }"
+            [ngClass]="{ active: item.id === selectedItem()?.id }"
+            mwlResizable
+            (click)="onEditControl(item)"
+            [enableGhostResize]="true">
+            <div class="placeholder" [ngStyle]="{ width: item.style.width }" *cdkDragPlaceholder></div>
 
-          @switch (item.type) {
-            @case (ControlTypes.INPUT) {
-              <app-input [control]="item"></app-input>
+            @switch (item.type) {
+              @case (ControlTypes.INPUT) {
+                <app-input [control]="item"></app-input>
+              }
+              @case (ControlTypes.TEXTAREA) {
+                <app-textarea [control]="item"></app-textarea>
+              }
+              @case (ControlTypes.BUTTON) {
+                <app-button [control]="item" />
+              }
+              @case (ControlTypes.TEXT) {
+                <app-text
+                  [control]="item"
+                  (toggleEditing)="toggleEditing($event.id, $event.value)"
+                  (updateText)="updateText($event.value, $event.id)" />
+              }
+              @default {
+                <app-span [control]="item" />
+              }
             }
-            @case (ControlTypes.TEXTAREA) {
-              <app-textarea [control]="item"></app-textarea>
-            }
-            @case (ControlTypes.BUTTON) {
-              <app-button [control]="item" />
-            }
-            @case (ControlTypes.TEXT) {
-              <app-text
-                [control]="item"
-                (toggleEditing)="toggleEditing($event.id, $event.value)"
-                (updateText)="updateText($event.value, $event.id)" />
-            }
-            @default {
-              <app-span [control]="item" />
-            }
-          }
 
-          <div class="action-block">
-            <button
-              class="bg-green-500 text-white font-bold px-2 mx-1 rounded"
-              (click)="increaseWidth($event, item.id, 2)">
-              +
-            </button>
-            <button
-              class="bg-red-500 text-white font-bold px-2 mx-1 rounded"
-              (click)="decreaseWidth($event, item.id, 2)">
-              -
-            </button>
-            <button class="font-bold px-1 mx-1 rounded" (click)="remove($event, item.id)">x</button>
+            <div class="action-block">
+              <button
+                class="bg-green-500 text-white font-bold px-2 mx-1 rounded"
+                (click)="increaseWidth($event, item.id, 2)">
+                +
+              </button>
+              <button
+                class="bg-red-500 text-white font-bold px-2 mx-1 rounded"
+                (click)="decreaseWidth($event, item.id, 2)">
+                -
+              </button>
+              <button class="font-bold px-1 mx-1 rounded" (click)="remove($event, item.id)">x</button>
+            </div>
           </div>
-        </div>
-      } @empty {
-        <app-empty-area />
-      }
+        }
+      </div>
+    }
+
+    <!--  "New row" drop-zone at the bottom  -->
+    <div
+      class="drop-new-row flex items-center justify-start w-full h-12 mb-2"
+      cdkDropList
+      id="new-row"
+      cdkDropListOrientation="horizontal"
+      [cdkDropListData]="newRowData"
+      [cdkDropListConnectedTo]="dropListIds()"
+      (cdkDropListDropped)="onDropToNewRow($event)">
+      <div class="placeholder w-full h-full" *cdkDropListPlaceholder></div>
+      <span class="ml-2">Drop here to create a new row</span>
     </div>
   </div>
 

--- a/src/app/pages/resize/resize.component.scss
+++ b/src/app/pages/resize/resize.component.scss
@@ -4,11 +4,16 @@
   right: 0px;
 }
 
-.drop-area {
-  flex: 1;
-  padding: 2px;
-  min-height: 200px;
-  background-color: #cfcfcf;
+.drop-row {
+  border: 1px dashed #ccc;
+  border-radius: 3px;
+  padding: 8px;
+}
+
+.drop-new-row {
+  border: 1px dashed #ccc;
+  border-radius: 3px;
+  color: #777;
 }
 
 .cdk-drag-animating {

--- a/src/app/pages/resize/result-preview/result-preview.component.ts
+++ b/src/app/pages/resize/result-preview/result-preview.component.ts
@@ -10,7 +10,7 @@ import { ViewerComponent } from '../viewer/viewer.component';
 })
 export class ResultPreviewComponent {
   @Input() open = false;
-  @Input() layoutConfig: LayoutItemConfig[] = [];
+  @Input() layoutConfig: LayoutItemConfig[][] = [[]];
   @Output() closed = new EventEmitter<boolean>();
 
   constructor() {

--- a/src/app/pages/resize/source-code-preview/source-code-preview.component.ts
+++ b/src/app/pages/resize/source-code-preview/source-code-preview.component.ts
@@ -10,6 +10,6 @@ import { NgxJsonViewerModule } from 'ngx-json-viewer';
 })
 export class SourceCodePreviewComponent {
   @Input() open = false;
-  @Input() layoutConfig: LayoutItemConfig[] = [];
+  @Input() layoutConfig: LayoutItemConfig[][] = [[]];
   @Output() closed = new EventEmitter<boolean>();
 }

--- a/src/app/pages/resize/viewer/viewer.component.html
+++ b/src/app/pages/resize/viewer/viewer.component.html
@@ -1,57 +1,61 @@
 <form [formGroup]="myForm" (ngSubmit)="onSubmit()">
-  <div class="flex flex-wrap">
-    @for (control of layoutConfig; track control.id) {
-      @if (control.type === 'text') {
-        <h3
-          class="relative mb-2 p-4 flex items-center flex-wrap"
-          [ngStyle]="{
-            width: control.style.width,
-          }">
-          {{ control.name }}
-        </h3>
-      }
-
-      @if (['input', 'password', 'email', 'number', 'search', 'tel', 'url'].includes(control.type)) {
-        <div
-          class="relative mb-2 p-4 flex items-center flex-wrap"
-          [ngStyle]="{
-            width: control.style.width,
-          }">
-          @if (control.name !== '') {
-            <label [for]="control.name">{{ control.name }}</label>
+  <div class="flex flex-col">
+    @for (row of layoutConfig; let ri = $index; track ri) {
+      <div class="flex">
+        @for (control of row; track control.id) {
+          @if (control.type === 'text') {
+            <h3
+              class="relative mb-2 p-4 flex items-center flex-wrap"
+              [ngStyle]="{
+                width: control.style.width,
+              }">
+              {{ control.name }}
+            </h3>
           }
-          <input [type]="control.type" [formControlName]="control.name" [id]="control.name" />
-        </div>
-      }
 
-      @if (control.type === 'textarea') {
-        <div
-          class="relative mb-2 p-4 flex items-center flex-wrap"
-          [ngStyle]="{
-            width: control.style.width,
-          }">
-          @if (control.name !== '') {
-            <label [for]="control.name">{{ control.name }}</label>
+          @if (['input', 'password', 'email', 'number', 'search', 'tel', 'url'].includes(control.type)) {
+            <div
+              class="relative mb-2 p-4 flex items-center flex-wrap"
+              [ngStyle]="{
+                width: control.style.width,
+              }">
+              @if (control.name !== '') {
+                <label [for]="control.name">{{ control.name }}</label>
+              }
+              <input [type]="control.type" [formControlName]="control.name" [id]="control.name" />
+            </div>
           }
-          <textarea [formControlName]="control.name"></textarea>
-        </div>
-      }
 
-      @if (control.type === 'button') {
-        <div
-          class="relative mb-2 p-4 flex items-center flex-wrap"
-          [ngStyle]="{
-            width: control.style.width,
-          }">
-          <button class="py-2 px-4 text-white bg-indigo-600">{{ control.name }}</button>
-        </div>
-      }
+          @if (control.type === 'textarea') {
+            <div
+              class="relative mb-2 p-4 flex items-center flex-wrap"
+              [ngStyle]="{
+                width: control.style.width,
+              }">
+              @if (control.name !== '') {
+                <label [for]="control.name">{{ control.name }}</label>
+              }
+              <textarea [formControlName]="control.name"></textarea>
+            </div>
+          }
 
-      @if (myForm.get(control.name)?.invalid && myForm.get(control.name)?.touched) {
-        @if (myForm.get(control.name)?.errors?.['required']) {
-          <bb-validation-message [control]="myForm.get(control.name)!"></bb-validation-message>
+          @if (control.type === 'button') {
+            <div
+              class="relative mb-2 p-4 flex items-center flex-wrap"
+              [ngStyle]="{
+                width: control.style.width,
+              }">
+              <button class="py-2 px-4 text-white bg-indigo-600">{{ control.name }}</button>
+            </div>
+          }
+
+          @if (myForm.get(control.name)?.invalid && myForm.get(control.name)?.touched) {
+            @if (myForm.get(control.name)?.errors?.['required']) {
+              <bb-validation-message [control]="myForm.get(control.name)!"></bb-validation-message>
+            }
+          }
         }
-      }
+      </div>
     }
   </div>
 </form>

--- a/src/app/pages/resize/viewer/viewer.component.spec.ts
+++ b/src/app/pages/resize/viewer/viewer.component.spec.ts
@@ -8,9 +8,8 @@ describe('ViewerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ViewerComponent]
-    })
-    .compileComponents();
+      imports: [ViewerComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ViewerComponent);
     component = fixture.componentInstance;

--- a/src/app/pages/resize/viewer/viewer.component.ts
+++ b/src/app/pages/resize/viewer/viewer.component.ts
@@ -13,14 +13,14 @@ import { CommonModule } from '@angular/common';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ViewerComponent implements OnInit {
-  @Input() layoutConfig: LayoutItemConfig[] = [];
+  @Input() layoutConfig: LayoutItemConfig[][] = [];
 
   private fb = inject(FormBuilder);
   private http = inject(HttpClient);
   public myForm: FormGroup = this.fb.group({});
 
   ngOnInit(): void {
-    this.createForm(this.layoutConfig);
+    this.createForm(this.layoutConfig.flat());
   }
 
   createForm(json: LayoutItemConfig[]) {


### PR DESCRIPTION
Refactored `layoutConfig` from a flat `LayoutItemConfig[]` to a two-dimensional `LayoutItemConfig[][]` signal.
A row-based model gives better control over layout (no more automatic wrapping).

https://github.com/user-attachments/assets/8ed48aad-5f40-4a08-8188-0466e3156693